### PR TITLE
Remove version from `generate-stackbrew-library.sh` output.

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -8,6 +8,6 @@ fullVersion="$(grep -m1 'ENV LOGSTASH_VERSION' Dockerfile | cut -d' ' -f3)"
 version="${fullVersion%[.-]*}"
 
 echo '# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)'
-echo "$version: ${url}@${commit} $version"
-echo "latest: ${url}@${commit} $version"
+echo "$version: ${url}@${commit}"
+echo "latest: ${url}@${commit}"
 


### PR DESCRIPTION
Fixes a mistake where the version is specified, but there's no corresponding directory due to there being only one maintained version.
