### PR TITLE
Use java:7-jre as a base instead of elasticsearch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:1.4
+FROM java:7-jre
 
 ENV LOGSTASH_VERSION 1.4.2
 


### PR DESCRIPTION
I've tested this out with the following Dockerfile and embedded ES works fine. I'm pretty sure the base install of ES was just being ignored and taking up space.

``` Dockerfile
FROM logstash
RUN echo 'input { tcp { type => "apache" port => 3333 } } filter { if [type] == "apache" { grok { match => { "message" => "%{COMBINEDAPACHELOG}" } } date { match => [ "timestamp", "dd/MMM/yyyy:HH:mm:ss Z" ] } } } output { elasticsearch { embedded => true } }' > /etc/logstash.conf
CMD ["logstash", "agent", "-f", "/etc/logstash.conf", "web"]
EXPOSE 3333 9292
```

Run like so:

```
# Put the above snipped into a Dockerfile
docker build -t logstash-test .
docker run -d -p 3333:3333 -p 9200:9200 -p 9292:9292 logstash-test
```

Fixes #4 
