### PR TITLE
Allow java executable to bind to privileged ports

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,7 @@ fi
 
 # Run as user "logstash" if the command is "logstash"
 if [ "$1" = 'logstash' ]; then
+	setcap 'cap_net_bind_service=+ep' $(readlink -f "$(which java)")
 	set -- gosu logstash "$@"
 fi
 


### PR DESCRIPTION
The logstash container is not allowed to bind on privileged ports.
Logstash provides some inputs whose default ports are in the privileged range. At least imap and syslog.
#### To reproduce

```
$ docker run --rm -ti logstash -e 'input { syslog { port => 514 } } output { stdout { } }'
syslog tcp listener died {:address=>"0.0.0.0:514", :exception=>#<Errno::EACCES: Permission denied - bind(2)>, :backtrace=>["org/jruby/ext/socket/RubyTCPServer.java:124:in `initialize'", "org/jruby/RubyIO.java:852:in `new'", "/opt/logstash/lib/logstash/inputs/syslog.rb:135:in `tcp_listener'", "/opt/logstash/lib/logstash/inputs/syslog.rb:90:in `run'"], :level=>:warn}
```
#### Use case

I want application containers to forward their logs to a syslog server (default port 514). In reality, the syslog server is a logstash container with a syslog input configured.

I use `--link` to bind application containers with logstash container so that application containers can use the `LOGSTASH_PORT_514_TCP_ADDR` environment variable to configure themself. Thus it requires logstash container to expose the 514 port.
