### PR TITLE
move to Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7-jre
+FROM java:8-jre
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4


### PR DESCRIPTION
Move to java 8 since it is recommended by upstream `logstash`:

> WARN -- Concurrent: [DEPRECATED] Java 7 is deprecated, please use Java 8.
> Java 7 support is only best effort, it may not work. It will be removed in next release (1.0).
