### PR TITLE
Update to 2.0.0 beta3

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -15,7 +15,7 @@ RUN arch="$(dpkg --print-architecture)" \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV LOGSTASH_MAJOR 2.0
-ENV LOGSTASH_VERSION 1:2.0.0-beta2-1
+ENV LOGSTASH_VERSION 1:2.0.0-beta3-1
 
 RUN echo "deb http://packages.elasticsearch.org/logstash/${LOGSTASH_MAJOR}/debian stable main" > /etc/apt/sources.list.d/logstash.list
 


### PR DESCRIPTION
Release note: https://www.elastic.co/blog/logstash-2-0-0-beta3-released
