### PR TITLE
Add "LS_SETTINGS_DIR" for 5.0+

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -39,6 +39,13 @@ ENV PATH /opt/logstash/bin:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH /opt/logstash/bin:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -39,6 +39,13 @@ ENV PATH /opt/logstash/bin:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH /opt/logstash/bin:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -39,6 +39,13 @@ ENV PATH /opt/logstash/bin:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH /opt/logstash/bin:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -39,6 +39,13 @@ ENV PATH /opt/logstash/bin:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH /opt/logstash/bin:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -39,6 +39,13 @@ ENV PATH /opt/logstash/bin:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH /opt/logstash/bin:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH /usr/share/logstash/bin:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -39,6 +39,13 @@ ENV PATH /usr/share/logstash/bin:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -37,6 +37,9 @@ RUN set -x \
 
 ENV PATH %%LOGSTASH_PATH%%:$PATH
 
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -50,4 +50,4 @@ RUN set -ex \
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["logstash", "agent"]
+CMD ["-e", ""]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -39,6 +39,13 @@ ENV PATH %%LOGSTASH_PATH%%:$PATH
 
 # necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
 ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.log: logs should go to stdout
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex \
+	&& if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^(path.log|path.config):!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
Without this, we get:

``` console
$ docker run -it --rm logstash:5 -e 'input { stdin { } } output { stdout { } } }'
--- jar coordinate com.fasterxml.jackson.core:jackson-annotations already loaded with version 2.7.1 - omit version 2.7.0
--- jar coordinate com.fasterxml.jackson.core:jackson-databind already loaded with version 2.7.1 - omit version 2.7.1-1
Logstash has a new settings file which defines start up time settings. This file is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a package and are starting it manually please specify the location to this settings file by passing in "--path.settings=/path/.." in the command line options {:level=>:warn}
Failed to load settings file from "path.settings". Aborting... {"path.settings"=>"/usr/share/logstash/config", "exception"=>Errno::ENOENT, "message"=>"No such file or directory - /usr/share/logstash/config/logstash.yml", :level=>:fatal}

$ docker run -it --rm logstash:5 --help
--- jar coordinate com.fasterxml.jackson.core:jackson-annotations already loaded with version 2.7.1 - omit version 2.7.0
--- jar coordinate com.fasterxml.jackson.core:jackson-databind already loaded with version 2.7.1 - omit version 2.7.1-1
Logstash has a new settings file which defines start up time settings. This file is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a package and are starting it manually please specify the location to this settings file by passing in "--path.settings=/path/.." in the command line options {:level=>:warn}
Failed to load settings file from "path.settings". Aborting... {"path.settings"=>"/usr/share/logstash/config", "exception"=>Errno::ENOENT, "message"=>"No such file or directory - /usr/share/logstash/config/logstash.yml", :level=>:fatal}

$ docker run -it --rm -e LS_SETTINGS_DIR=/etc/logstash logstash:5 --help
--- jar coordinate com.fasterxml.jackson.core:jackson-annotations already loaded with version 2.7.1 - omit version 2.7.0
--- jar coordinate com.fasterxml.jackson.core:jackson-databind already loaded with version 2.7.1 - omit version 2.7.1-1
Usage:
    bin/logstash [OPTIONS]

Options:
    ...

$ docker run -it --rm -e LS_SETTINGS_DIR=/etc/logstash logstash:5 --path.settings /omg --help
--- jar coordinate com.fasterxml.jackson.core:jackson-annotations already loaded with version 2.7.1 - omit version 2.7.0
--- jar coordinate com.fasterxml.jackson.core:jackson-databind already loaded with version 2.7.1 - omit version 2.7.1-1
Logstash has a new settings file which defines start up time settings. This file is typically located in $LS_HOME/config or /etc/logstash. If you installed Logstash through a package and are starting it manually please specify the location to this settings file by passing in "--path.settings=/path/.." in the command line options {:level=>:warn}
Failed to load settings file from "path.settings". Aborting... {"path.settings"=>"/omg", "exception"=>Errno::ENOENT, "message"=>"No such file or directory - /omg/logstash.yml", :level=>:fatal}

$ docker run -it --rm -e LS_SETTINGS_DIR=/etc/logstash logstash --help
Usage:
    /bin/logstash agent [OPTIONS]

Options:
    ...
```
