### PR TITLE
Update to 2.3.4

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
 
 ENV LOGSTASH_MAJOR 2.3
-ENV LOGSTASH_VERSION 1:2.3.3-1
+ENV LOGSTASH_VERSION 1:2.3.4-1
 
 RUN echo "deb http://packages.elastic.co/logstash/${LOGSTASH_MAJOR}/debian stable main" > /etc/apt/sources.list.d/logstash.list
 


### PR DESCRIPTION
Release: https://www.elastic.co/blog/logstash-2-3-4-released
