### PR TITLE
Allow arbitrary "--user" values (skip "gosu" unless we're running as root)

### DIFF
--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/2.0/docker-entrypoint.sh
+++ b/2.0/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/2.3/docker-entrypoint.sh
+++ b/2.3/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,8 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 # Run as user "logstash" if the command is "logstash"
-if [ "$1" = 'logstash' ]; then
+# allow the container to be started with `--user`
+if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
 	set -- gosu logstash "$@"
 fi
 


### PR DESCRIPTION
Fixes #11

See also https://github.com/docker-library/elasticsearch/pull/77