### PR TITLE
Remove auto su-exec

### DIFF
--- a/5/alpine/docker-entrypoint.sh
+++ b/5/alpine/docker-entrypoint.sh
@@ -6,10 +6,4 @@ if [ "${1#-}" != "$1" ]; then
 	set -- logstash "$@"
 fi
 
-# Run as user "logstash" if the command is "logstash"
-# allow the container to be started with `--user`
-if [ "$1" = 'logstash' -a "$(id -u)" = '0' ]; then
-	set -- su-exec logstash "$@"
-fi
-
 exec "$@"


### PR DESCRIPTION
`--user` option in `docker run` should be directly used as the user specified user account to run a logstash process. Entrypoint should not take it.