### PR TITLE
Use "/etc/apt/trusted.gpg.d" instead of "apt-key adv"

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -22,10 +22,16 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true
 
-# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
+RUN set -ex; \
 # https://artifacts.elastic.co/GPG-KEY-elasticsearch
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+	key='46095ACC8548582C1A2699A9D27D666CD88E42B4'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/elastic.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
+# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
 RUN echo 'deb http://packages.elastic.co/logstash/1.5/debian stable main' > /etc/apt/sources.list.d/logstash.list
 
 ENV LOGSTASH_VERSION 1.5.6

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -22,10 +22,16 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true
 
-# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
+RUN set -ex; \
 # https://artifacts.elastic.co/GPG-KEY-elasticsearch
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+	key='46095ACC8548582C1A2699A9D27D666CD88E42B4'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/elastic.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
+# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
 RUN echo 'deb http://packages.elastic.co/logstash/2.4/debian stable main' > /etc/apt/sources.list.d/logstash.list
 
 ENV LOGSTASH_VERSION 2.4.1

--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -22,10 +22,16 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true
 
-# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
+RUN set -ex; \
 # https://artifacts.elastic.co/GPG-KEY-elasticsearch
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+	key='46095ACC8548582C1A2699A9D27D666CD88E42B4'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/elastic.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
+# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
 RUN echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/apt/sources.list.d/logstash.list
 
 ENV LOGSTASH_VERSION 5.1.1

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -22,10 +22,16 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true
 
-# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
+RUN set -ex; \
 # https://artifacts.elastic.co/GPG-KEY-elasticsearch
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+	key='46095ACC8548582C1A2699A9D27D666CD88E42B4'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	gpg --export "$key" > /etc/apt/trusted.gpg.d/elastic.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
 
+# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
 RUN echo 'deb %%LOGSTASH_DEB_REPO%% stable main' > /etc/apt/sources.list.d/logstash.list
 
 ENV LOGSTASH_VERSION %%LOGSTASH_VERSION%%


### PR DESCRIPTION
> Note: Instead of using this command a keyring should be placed
> directly in the /etc/apt/trusted.gpg.d/ directory with a
> descriptive name and either "gpg" or "asc" as file extension.

https://manpages.debian.org/cgi-bin/man.cgi?query=apt-key&manpath=Debian+testing+stretch

See also docker-library/cassandra#91, docker-library/mariadb#93, docker-library/mongo#132, docker-library/mysql#254, docker-library/percona#39, docker-library/postgres#246, and https://github.com/docker-library/elasticsearch/pull/152.