### PR TITLE
Install libc6-compat on Alpine variant

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,6 +7,7 @@ RUN addgroup -S logstash && adduser -S -G logstash logstash
 RUN apk add --no-cache \
 # env: can't execute 'bash': No such file or directory
 		bash \
+		libc6-compat \
 		libzmq
 
 # grab su-exec for easy step-down from root


### PR DESCRIPTION
Logstash's `file` input performs some `stat` operations that require
`libcrypt.so.1` to be installed.

Fix docker-library/logstash#81