### PR TITLE
DEVOPS-63 - support logstash-6.x

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -48,6 +48,6 @@ RUN set -ex \
 	fi
 
 COPY docker-entrypoint.sh /
-EXPOSE 5043 12201
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -48,6 +48,6 @@ RUN set -ex \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-EXPOSE 5043 12201
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -52,6 +52,6 @@ RUN set -ex; \
 	fi
 
 COPY docker-entrypoint.sh /
-
+EXPOSE 5043 12201/udp
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["-e", ""]

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,0 +1,58 @@
+FROM openjdk:8-jre
+
+# install plugin dependencies
+RUN apt-get update && \
+		apt-get install -y --no-install-recommends \
+		apt-transport-https \
+		libzmq5 \
+	&& rm -rf /var/lib/apt/lists/*
+
+# the "ffi-rzmq-core" gem is very picky about where it looks for libzmq.so
+RUN mkdir -p /usr/local/lib \
+	&& ln -s /usr/lib/*/libzmq.so.3 /usr/local/lib/libzmq.so
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+# https://www.elastic.co/guide/en/logstash/5.0/installing-logstash.html#_apt
+# https://artifacts.elastic.co/GPG-KEY-elasticsearch
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4
+
+RUN echo 'deb https://artifacts.elastic.co/packages/6.x/apt stable main' > /etc/apt/sources.list.d/logstash.list
+
+ENV LOGSTASH_VERSION 1:6.3.2-1
+
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends logstash=$LOGSTASH_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PATH /usr/share/logstash/bin:$PATH
+
+# necessary for 5.0+ (overriden via "--path.settings", ignored by < 5.0)
+ENV LS_SETTINGS_DIR /etc/logstash
+# comment out some troublesome configuration parameters
+#   path.config: No config files found: /etc/logstash/conf.d/*
+RUN set -ex; \
+	if [ -f "$LS_SETTINGS_DIR/logstash.yml" ]; then \
+		sed -ri 's!^path\.config:!#&!g' "$LS_SETTINGS_DIR/logstash.yml"; \
+	fi; \
+# if the "log4j2.properties" file exists (logstash 5.x), let's empty it out so we get the default: "logging only errors to the console"
+	if [ -f "$LS_SETTINGS_DIR/log4j2.properties" ]; then \
+		cp "$LS_SETTINGS_DIR/log4j2.properties" "$LS_SETTINGS_DIR/log4j2.properties.dist"; \
+		truncate --size=0 "$LS_SETTINGS_DIR/log4j2.properties"; \
+	fi
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["-e", ""]

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Add logstash as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- logstash "$@"
+fi
+
+# Run as user "logstash" if the command is "logstash"
+if [ "$1" = 'logstash' ]; then
+	set -- gosu logstash "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Our new logging config should use a recent version of logstash for bugfix and performance reasons, so i wanted to be able to build a 6.x logstash container image.
