### PR TITLE
Add "docker build" example command to generated Dockerfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - id: generate-jobs
         name: Generate Jobs
         run: |
@@ -33,7 +33,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,70 @@
+name: Upstream Diff
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: 0 0 * * 0
+
+defaults:
+  run:
+    shell: 'bash -Eeuo pipefail -x {0}'
+
+jobs:
+
+  generate:
+    name: Generate Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.generate.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: generate
+        name: Generate Matrix
+        run: |
+          versions=( */ )
+          versions=( "${versions[@]%/}" )
+          IFS=$'\n'
+          versionsJson="$(IFS=$'\n'; jq <<<"${versions[*]}" -csR 'rtrimstr("\n") | split("\n")')"
+          echo "::set-output name=versions::$versionsJson"
+
+  diff:
+    needs: generate
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.generate.outputs.versions) }}
+      fail-fast: false
+    name: ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    env:
+      version: ${{ matrix.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Gather Data
+        run: |
+          upstreamImage="$(awk '$1 == "FROM" { print $2; exit }' "$version/Dockerfile")"
+          [ -n "$upstreamImage" ] # sanity check
+          echo "::set-env name=upstreamImage::$upstreamImage"
+          buildImage="$GITHUB_REPOSITORY:$version"
+          echo "::set-env name=buildImage::$buildImage"
+          dockerBuild="$(gawk '$1 == "#" && $2 == "docker" && $3 == "build" { gsub(/^#[[:space:]]+/, ""); print }' "$version/Dockerfile")"
+          [ -n "$dockerBuild" ] # sanity check
+          dockerBuild+=" --pull --tag '$buildImage'"
+          echo "::set-env name=dockerBuild::$dockerBuild"
+      - name: Pull
+        run: |
+          docker pull "$upstreamImage"
+      - name: Build
+        run: |
+          eval "$dockerBuild"
+      - name: Diff
+        run: |
+          diff -u <(.github/workflows/history.sh "$upstreamImage") <(.github/workflows/history.sh "$buildImage")
+      - name: Overall Size
+        run: |
+          docker image ls "${upstreamImage%%:*}"
+          docker image ls "${buildImage%%:*}"
+      - name: Full History
+        run: |
+          docker image history "$upstreamImage"
+          docker image history "$buildImage"

--- a/.github/workflows/history.sh
+++ b/.github/workflows/history.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# "docker history", but ignoring/munging known problematic bits for the purposes of creating image diffs
+
+docker image history --no-trunc --format '{{ .CreatedBy }}' "$@" \
+	| tac \
+	| sed -r 's!^/bin/sh[[:space:]]+-c[[:space:]]+(#[(]nop[)][[:space:]]+)?!!' \
+	| awk '
+		# ignore the first ADD of the base image (base image changes unnecessarily break our diffs)
+		NR == 1 && $1 == "ADD" && $4 == "/" { next }
+		# TODO consider instead just removing the checksum in $3
+
+		# ignore obviously "centos" LABEL instructions (include a timestamp, so base image changes unnecessarily break our diffs)
+		$1 == "LABEL" && / org.opencontainers.image.vendor=CentOS | org.label-schema.vendor=CentOS / { next }
+
+		# just ignore the default CentOS CMD value (not relevant to our needs)
+		$0 == "CMD [\"/bin/bash\"]" { next }
+
+		# in logstash, Elastic builds pull artifacts from "http://localhost:8000" instead of "https://artifacts.elastic.co/downloads/logstash"
+		/localhost:8000\/logstash/ { gsub(/http:\/\/localhost:8000\/logstash/, "https://artifacts.elastic.co/downloads/logstash/logstash") }
+
+		# sane and sanitized, print it!
+		{ print }
+	'

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -6,6 +6,9 @@ FROM docker.elastic.co/logstash/logstash:6.8.9@sha256:0ed94c58fd5c706867d19a0b26
 # The upstream image was built by:
 #   https://github.com/elastic/dockerfiles/tree/v6.8.9/logstash
 
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v6.8.9:logstash'
+
 # For a full list of supported images and tags visit https://www.docker.elastic.co
 
 # For Logstash documentation visit https://www.elastic.co/guide/en/logstash/current/docker.html

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -6,6 +6,9 @@ FROM docker.elastic.co/logstash/logstash:7.7.0@sha256:389ba939d3ca1087929215713f
 # The upstream image was built by:
 #   https://github.com/elastic/dockerfiles/tree/v7.7.0/logstash
 
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v7.7.0:logstash'
+
 # For a full list of supported images and tags visit https://www.docker.elastic.co
 
 # For Logstash documentation visit https://www.elastic.co/guide/en/logstash/current/docker.html

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,10 +1,13 @@
-# Logstash %%LOGSTASH_VERSION%%
+# Logstash %%VERSION%%
 
 # This image re-bundles the Docker image from the upstream provider, Elastic.
 FROM %%UPSTREAM_IMAGE_DIGEST%%
 
 # The upstream image was built by:
 #   %%UPSTREAM_DOCKERFILE_LINK%%
+
+# The build can be reproduced locally via:
+#   docker build '%%UPSTREAM_DOCKER_BUILD%%'
 
 # For a full list of supported images and tags visit https://www.docker.elastic.co
 

--- a/update.sh
+++ b/update.sh
@@ -9,8 +9,12 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
+upstreamProduct='logstash'
+
+upstreamDockerfileRepo='https://github.com/elastic/dockerfiles'
+
 tags="$(
-	git ls-remote --tags https://github.com/elastic/dockerfiles.git \
+	git ls-remote --tags "$upstreamDockerfileRepo.git" \
 		| cut -d/ -f3 \
 		| grep -E '^v' \
 		| cut -d^ -f1 \
@@ -37,16 +41,18 @@ for version in "${versions[@]}"; do
 
 	echo "$version: $fullVersion"
 
-	upstreamImage="docker.elastic.co/logstash/logstash:$fullVersion"
+	upstreamImageRepo="$upstreamProduct/$upstreamProduct"
+	upstreamImage="docker.elastic.co/$upstreamImageRepo:$fullVersion"
 
 	# Parse image manifest for sha
-	authToken="$(curl -fsSL 'https://docker-auth.elastic.co/auth?service=token-service&scope=repository:logstash/logstash:pull' | jq -r .token)"
-	digest="$(curl --head -fsSL -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' -H "Authorization: Bearer $authToken" "https://docker.elastic.co/v2/logstash/logstash/manifests/$fullVersion" | tr -d '\r' | gawk -F ':[[:space:]]+' '$1 == "Docker-Content-Digest" { print $2 }')"
+	authToken="$(curl -fsSL "https://docker-auth.elastic.co/auth?service=token-service&scope=repository:$upstreamImageRepo:pull" | jq -r .token)"
+	digest="$(curl --head -fsSL -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' -H "Authorization: Bearer $authToken" "https://docker.elastic.co/v2/$upstreamImageRepo/manifests/$fullVersion" | tr -d '\r' | gawk -F ':[[:space:]]+' '$1 == "Docker-Content-Digest" { print $2 }')"
 
 	# Format image reference (image@sha)
 	upstreamImageDigest="$upstreamImage@$digest"
 
-	upstreamDockerfileLink="https://github.com/elastic/dockerfiles/tree/v$fullVersion/logstash"
+	upstreamDockerfileTag="v$fullVersion"
+	upstreamDockerfileLink="https://github.com/elastic/dockerfiles/tree/$upstreamDockerfileTag/$upstreamProduct"
 	upstreamDockerfile="${upstreamDockerfileLink//tree/raw}/Dockerfile"
 
 	(
@@ -55,8 +61,11 @@ for version in "${versions[@]}"; do
 		curl -fsSL "$upstreamDockerfile" | grep -P "\Q$fullVersion" # ... and that it contains the right version
 	)
 
-	sed -e 's!%%LOGSTASH_VERSION%%!'"$fullVersion"'!g' \
+	upstreamDockerBuild="$upstreamDockerfileRepo.git#$upstreamDockerfileTag:$upstreamProduct"
+
+	sed -e 's!%%VERSION%%!'"$fullVersion"'!g' \
 		-e 's!%%UPSTREAM_IMAGE_DIGEST%%!'"$upstreamImageDigest"'!g' \
 		-e 's!%%UPSTREAM_DOCKERFILE_LINK%%!'"$upstreamDockerfileLink"'!g' \
+		-e 's!%%UPSTREAM_DOCKER_BUILD%%!'"$upstreamDockerBuild"'!g' \
 		Dockerfile.template > "$version/Dockerfile"
 done


### PR DESCRIPTION
Also, add a new GitHub Action to do a very surface-level verification of the published images vs the published build context.

See also https://github.com/docker-library/elasticsearch/pull/193.

This is the logstash-specific bit over what's tested/handled in `elasticsearch`:

```diff
--- /dev/fd/63	2020-05-13 19:20:02.688874046 +0000
+++ /dev/fd/62	2020-05-13 19:20:02.688874046 +0000
@@ -1,6 +1,6 @@
 yum update -y && yum install -y java-11-openjdk-devel which &&     yum clean all
 groupadd --gid 1000 logstash &&     adduser --uid 1000 --gid 1000       --home-dir /usr/share/logstash --no-create-home       logstash
-curl -Lo - http://localhost:8000/logstash-7.7.0.tar.gz |     tar zxf - -C /usr/share &&     mv /usr/share/logstash-7.7.0 /usr/share/logstash &&     chown --recursive logstash:logstash /usr/share/logstash/ &&     chown -R logstash:root /usr/share/logstash &&     chmod -R g=u /usr/share/logstash &&     find /usr/share/logstash -type d -exec chmod g+s {} \; &&     ln -s /usr/share/logstash /opt/logstash
+curl -Lo - https://artifacts.elastic.co/downloads/logstash/logstash-7.7.0.tar.gz |     tar zxf - -C /usr/share &&     mv /usr/share/logstash-7.7.0 /usr/share/logstash &&     chown --recursive logstash:logstash /usr/share/logstash/ &&     chown -R logstash:root /usr/share/logstash &&     chmod -R g=u /usr/share/logstash &&     find /usr/share/logstash -type d -exec chmod g+s {} \; &&     ln -s /usr/share/logstash /opt/logstash
 WORKDIR /usr/share/logstash
 ENV ELASTIC_CONTAINER=true
 ENV PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```