### PR TITLE
Temporary backfill of missed versions

### DIFF
--- a/7.17.11/Dockerfile
+++ b/7.17.11/Dockerfile
@@ -1,0 +1,17 @@
+# Logstash 7.17.11
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/logstash/logstash:7.17.11@sha256:a3362c43ca2885aa08b27831dbed18a8e3d851374efb6e663f6d18a2906c2730
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v7.17.11/logstash
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v7.17.11:logstash'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For Logstash documentation visit https://www.elastic.co/guide/en/logstash/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/5039 for more details.

--- a/8.8.2/Dockerfile
+++ b/8.8.2/Dockerfile
@@ -1,0 +1,17 @@
+# Logstash 8.8.2
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/logstash/logstash:8.8.2@sha256:d5bebfec7734a8b566cbbc1223427e1716d9048d81ce1b19f92b56c69fbbc34c
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v8.8.2/logstash
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v8.8.2:logstash'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For Logstash documentation visit https://www.elastic.co/guide/en/logstash/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/5039 for more details.

--- a/8.9.0/Dockerfile
+++ b/8.9.0/Dockerfile
@@ -1,0 +1,17 @@
+# Logstash 8.9.0
+
+# This image re-bundles the Docker image from the upstream provider, Elastic.
+FROM docker.elastic.co/logstash/logstash:8.9.0@sha256:ea6e03234a1537e5475606b1b7a56bef24cb219a549308825b932cee4a1623a4
+# Supported Bashbrew Architectures: amd64 arm64v8
+
+# The upstream image was built by:
+#   https://github.com/elastic/dockerfiles/tree/v8.9.0/logstash
+
+# The build can be reproduced locally via:
+#   docker build 'https://github.com/elastic/dockerfiles.git#v8.9.0:logstash'
+
+# For a full list of supported images and tags visit https://www.docker.elastic.co
+
+# For Logstash documentation visit https://www.elastic.co/guide/en/logstash/current/docker.html
+
+# See https://github.com/docker-library/official-images/pull/5039 for more details.

--- a/update.sh
+++ b/update.sh
@@ -29,7 +29,7 @@ for version in "${versions[@]}"; do
 	fi
 
 	fullVersion="$(
-		grep -P "^\Qv$rcVersion." <<<"$tags" \
+		grep -P "^\Qv$rcVersion" <<<"$tags" \
 			| grep $rcGrepV -E -- '-(alpha|beta|rc)' \
 			| tail -1
 	)"


### PR DESCRIPTION
This is just to fill in `7.17.11`, `8.8.2`, and `8.9.0`.

Once merged, we can open the revert PR immediately. Once the changes are referenced in `docker-library/official-images` we can merge the revert.

```diff
$ diff -u ../official-images/library/logstash <(./generate-stackbrew-library.sh)
--- ../official-images/library/logstash 2023-08-23 16:05:44.440405336 -0700
+++ /dev/fd/63  2023-08-23 16:06:42.015223995 -0700
@@ -4,11 +4,26 @@
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git

+Tags: 8.9.0
+Architectures: amd64, arm64v8
+GitCommit: 2105c9b1b6afcef578a932a55ad6625a196254ab
+Directory: 8.9.0
+
+Tags: 8.8.2
+Architectures: amd64, arm64v8
+GitCommit: 2105c9b1b6afcef578a932a55ad6625a196254ab
+Directory: 8.8.2
+
 Tags: 8.9.1
 Architectures: amd64, arm64v8
 GitCommit: 2ff314dcb3ed7b4bb812ca9fa3cdf72ca958e99f
 Directory: 8

+Tags: 7.17.11
+Architectures: amd64, arm64v8
+GitCommit: 2105c9b1b6afcef578a932a55ad6625a196254ab
+Directory: 7.17.11
+
 Tags: 7.17.12
 Architectures: amd64, arm64v8
 GitCommit: d94032bc7db1f3b62922a15f9e0eab7401fe479b
```

related to https://github.com/docker-library/elasticsearch/pull/208